### PR TITLE
Add setConfig method and use prebid configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install --save @schibstedspain/openads-appnexus-prebid
 # Usage
 
 To use it with OpenAds first you must install and import OpenAds as explained in the [readme](https://github.com/scm-spain/OpenAds)
-After that you must init the AppNexusConnector with the configuration member account
+After that you must init the AppNexusConnector with the configuration member account and your especific Prebid configuration
 Now you are able to put the instance as a source available in OpenAds configuration
 
 ```ecmascript 6
@@ -31,6 +31,13 @@ import AppNexusConnector from '@schibstedspain/openads-appnexus-prebid'
 const appNexusConnector = AppNexusConnector.init({
   config: {
     member: 4242
+  },
+  prebidConfig: {
+    config: {
+      bidderTimeout: 1000,
+      priceGranularity: "dense",
+      enableSendAllBids: false
+    }
   }
 })
 

--- a/src/openads-appnexus/AppNexusConnector.js
+++ b/src/openads-appnexus/AppNexusConnector.js
@@ -20,6 +20,7 @@ import Debouncer from './service/Debouncer'
 export default class AppNexusConnector {
   constructor({
     pageOpts,
+    prebidConfig,
     logger,
     astClient,
     adRepository,
@@ -32,9 +33,9 @@ export default class AppNexusConnector {
     this._loggerProvider = loggerProvider
     this._prebidClient = prebidClient
     this._pageOpts = pageOpts
-    if (this._pageOpts) {
-      this._astClient.setPageOpts(this._pageOpts)
-    }
+    this._prebidConfig = prebidConfig
+    if (this._pageOpts) this._astClient.setPageOpts(this._pageOpts)
+    if (this._prebidConfig) this._prebidClient.setConfig(this._prebidConfig)
     this._loadAdDebouncer = new Debouncer({
       onDebounce: this._onLoadAdDebounce.bind(this),
       debounceTimeout: TIMEOUT_DEBOUNCE
@@ -106,7 +107,7 @@ export default class AppNexusConnector {
         normalizedInputs.tags.forEach(input =>
           this._defineAppNexusTag({id: input.id, tag: input.data})
         )
-        if (normalizedInputs.adUnits.length > 0) {
+        if (normalizedInputs.adUnits.length > 0 && this._prebidClient) {
           this._prebidClient.addAdUnits({adUnits: normalizedInputs.adUnits})
           this._prebidClient.requestBids({
             timeout: TIMEOUT_PREBID,

--- a/src/openads-appnexus/Container.js
+++ b/src/openads-appnexus/Container.js
@@ -25,6 +25,7 @@ export default class Container {
   _buildAppNexusConnector() {
     return new AppNexusConnector({
       pageOpts: this._config.pageOpts,
+      prebidConfig: this._config.prebidConfig,
       loggerProvider: this.getInstance({key: 'LogProvider'}),
       logger: this.getInstance({key: 'Logger'}),
       astClient: this.getInstance({key: 'AstClient'}),

--- a/src/openads-appnexus/PrebidClient.js
+++ b/src/openads-appnexus/PrebidClient.js
@@ -29,4 +29,12 @@ export default class PrebidClient {
   setTargetngForAst() {
     throw new Error('AppNexusConnector#setTargetForAst must be implemented')
   }
+
+  /**
+   * Defines setConfig.
+   * @param config
+   */
+  setConfig(config) {
+    throw new Error('AppNexusConnector#setConfig must be implemented')
+  }
 }

--- a/src/openads-appnexus/PrebidClientImpl.js
+++ b/src/openads-appnexus/PrebidClientImpl.js
@@ -38,7 +38,7 @@ export default class PrebidClientImpl {
   }
 
   setConfig(config) {
-    this._logger.debug(this._logger.name, '| setConfig has been called.')
+    this._logger.debug(this._logger.name, '| setConfig | config:', config)
     this._pbjs.que.push(() => this._pbjs.setConfig(config))
     return this
   }

--- a/src/openads-appnexus/PrebidClientImpl.js
+++ b/src/openads-appnexus/PrebidClientImpl.js
@@ -36,4 +36,10 @@ export default class PrebidClientImpl {
     this._pbjs.que.push(() => this._pbjs.setTargetingForAst())
     return this
   }
+
+  setConfig(config) {
+    this._logger.debug(this._logger.name, '| setConfig has been called.')
+    this._pbjs.que.push(() => this._pbjs.setConfig(config))
+    return this
+  }
 }

--- a/src/test/openads-appnexus/PrebidClientImplTest.js
+++ b/src/test/openads-appnexus/PrebidClientImplTest.js
@@ -15,7 +15,8 @@ describe('PrebidClientImpl Test', () => {
     debug: false,
     addAdUnits: () => null,
     requestBids: () => null,
-    setTargetingForAst: () => null
+    setTargetingForAst: () => null,
+    setConfig: () => null
   })
 
   describe('constructor method', () => {
@@ -139,6 +140,31 @@ describe('PrebidClientImpl Test', () => {
       prebidClient.setTargetingForAst({adUnits: givenParameters})
       expect(queSpy.calledOnce).to.be.true
       expect(setTargetingForAstSpy.calledOnce).to.be.true
+    })
+  })
+
+  describe('setConfig method', () => {
+    it('should call the prebid setConfig method via que', () => {
+      const prebidMock = createPrebidMock()
+      const loggerMock = createLoggerMock()
+      const windowMock = {
+        pbjs: prebidMock
+      }
+      const prebidClient = new PrebidClientImpl({
+        logger: loggerMock,
+        window: windowMock
+      })
+      const givenPrebidConfig = {
+        bidderTimeout: 1500,
+        priceGranularity: 'dense',
+        enableSendAllBids: false
+      }
+      const queSpy = sinon.spy(prebidMock.que, 'push')
+      const setConfigSpy = sinon.spy(prebidMock, 'setConfig')
+
+      prebidClient.setConfig(givenPrebidConfig)
+      expect(queSpy.calledOnce).to.be.true
+      expect(setConfigSpy.calledOnce).to.be.true
     })
   })
 })


### PR DESCRIPTION
# Background

From Appnexus arrived a request to change the configuration that we send to Prebid.

# Goal

Add new parameters to the Prebid configuration

# Implementation

- Add new setConfig method to PrebidClient

# Checklist

- [ ] The PR relates to *only* one subject with a clear title.
- [ ] I have performed a self-review of my own code
- [ ] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ ] My code is readable by someone else, and I commented the hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# Visual description

*your meme goes here*
![](https://media.giphy.com/media/xT5LMVjsPH3wn2EXYc/giphy.gif)