### PR TITLE
Feature/add bidder settings method

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,13 @@ const appNexusConnector = AppNexusConnector.init({
     member: 4242
   },
   prebidConfig: {
-    config: {
+    core: {
       bidderTimeout: 1000,
       priceGranularity: "dense",
       enableSendAllBids: false
+    },
+    bidderSettings: {
+      ...
     }
   }
 })
@@ -47,6 +50,68 @@ const openAds = OpenAds.init({config:{
   }
 }})
 ```
+## Configuration
+
+Configuration object is divided in two objects:
+* **config**: related with AppNexus (ast.js)
+* **prebidConfig**: related with PreBid (pbjs.js)
+    * **core** : (Optional) Settings to override the default Prebid core configuration.
+    * **bidderSettings**: (Optional) Settings to override the default Prebid settings used by the bidders.
+
+### bidderSettings
+
+An example of **bidderSettings** overriding the standard configuration applied to all bidders:
+
+```json
+{
+    standard: {
+        adserverTargeting: [{
+            key: "hb_bidder",
+            val: function(bidResponse) {
+                return bidResponse.bidderCode;
+            }
+        }, {
+            key: "hb_adid",
+            val: function(bidResponse) {
+                return bidResponse.adId;
+            }
+        }, {
+            key: "hb_pb",
+            val: function(bidResponse) {
+                return bidResponse.pbMg;
+            }
+        }, {
+            key: 'hb_size',
+            val: function (bidResponse) {
+                return bidResponse.size;
+            }
+        }, {
+            key: 'hb_source',
+            val: function (bidResponse) {
+                return bidResponse.source;
+            }
+        }, {
+            key: 'hb_format',
+            val: function (bidResponse) {
+                return bidResponse.mediaType;
+            }
+        }, {
+            key: 'hb_cache_id',
+            val: function (bidResponse) {
+                return bidResponse.videoCacheKey;
+            }
+        }, {
+            key: 'hb_uuid',
+            val: function (bidResponse) {
+                return bidResponse.videoCacheKey;
+            }
+        }]
+    }
+}
+
+```
+
+More info can be found [here](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.bidderSettings).
 
 # Preconditions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads-appnexus-prebid",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "OpenAds AppNexus connector with Prebid features",
   "main": "dist/",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schibstedspain/openads-appnexus-prebid",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "OpenAds AppNexus connector with Prebid features",
   "main": "dist/",
   "scripts": {

--- a/src/openads-appnexus/AppNexusConnector.js
+++ b/src/openads-appnexus/AppNexusConnector.js
@@ -108,8 +108,10 @@ export default class AppNexusConnector {
         )
         if (normalizedInputs.adUnits.length > 0 && this._prebidClient) {
           this._prebidClient.addAdUnits({adUnits: normalizedInputs.adUnits})
-          if (this._prebidConfig)
-            this._prebidClient.setConfig(this._prebidConfig)
+
+          if (this._prebidConfig && this._prebidConfig.core)
+            this._prebidClient.setConfig(this._prebidConfig.core)
+
           this._prebidClient.requestBids({
             timeout: TIMEOUT_PREBID,
             bidsBackHandler: () => {
@@ -117,6 +119,11 @@ export default class AppNexusConnector {
               this._astClient.loadTags()
             }
           })
+
+          if (this._prebidConfig && this._prebidConfig.bidderSettings)
+            this._prebidClient.setBidderSettings(
+              this._prebidConfig.bidderSettings
+            )
         } else {
           this._astClient.loadTags()
         }

--- a/src/openads-appnexus/AppNexusConnector.js
+++ b/src/openads-appnexus/AppNexusConnector.js
@@ -34,7 +34,13 @@ export default class AppNexusConnector {
     this._prebidClient = prebidClient
     this._pageOpts = pageOpts
     this._prebidConfig = prebidConfig
-    if (this._pageOpts) this._astClient.setPageOpts(this._pageOpts)
+
+    if (this._pageOpts) {
+      this._astClient.setPageOpts(this._pageOpts)
+    }
+
+    this._prebidClient.setConfig({config: this._prebidConfig})
+
     this._loadAdDebouncer = new Debouncer({
       onDebounce: this._onLoadAdDebounce.bind(this),
       debounceTimeout: TIMEOUT_DEBOUNCE
@@ -109,10 +115,6 @@ export default class AppNexusConnector {
         if (normalizedInputs.adUnits.length > 0 && this._prebidClient) {
           this._prebidClient.addAdUnits({adUnits: normalizedInputs.adUnits})
 
-          if (this._prebidConfig && this._prebidConfig.core) {
-            this._prebidClient.setConfig(this._prebidConfig.core)
-          }
-
           this._prebidClient.requestBids({
             timeout: TIMEOUT_PREBID,
             bidsBackHandler: () => {
@@ -120,12 +122,6 @@ export default class AppNexusConnector {
               this._astClient.loadTags()
             }
           })
-
-          if (this._prebidConfig && this._prebidConfig.bidderSettings) {
-            this._prebidClient.setBidderSettings(
-              this._prebidConfig.bidderSettings
-            )
-          }
         } else {
           this._astClient.loadTags()
         }

--- a/src/openads-appnexus/AppNexusConnector.js
+++ b/src/openads-appnexus/AppNexusConnector.js
@@ -109,8 +109,9 @@ export default class AppNexusConnector {
         if (normalizedInputs.adUnits.length > 0 && this._prebidClient) {
           this._prebidClient.addAdUnits({adUnits: normalizedInputs.adUnits})
 
-          if (this._prebidConfig && this._prebidConfig.core)
+          if (this._prebidConfig && this._prebidConfig.core) {
             this._prebidClient.setConfig(this._prebidConfig.core)
+          }
 
           this._prebidClient.requestBids({
             timeout: TIMEOUT_PREBID,
@@ -120,10 +121,11 @@ export default class AppNexusConnector {
             }
           })
 
-          if (this._prebidConfig && this._prebidConfig.bidderSettings)
+          if (this._prebidConfig && this._prebidConfig.bidderSettings) {
             this._prebidClient.setBidderSettings(
               this._prebidConfig.bidderSettings
             )
+          }
         } else {
           this._astClient.loadTags()
         }

--- a/src/openads-appnexus/PrebidClient.js
+++ b/src/openads-appnexus/PrebidClient.js
@@ -37,4 +37,12 @@ export default class PrebidClient {
   setConfig(config) {
     throw new Error('AppNexusConnector#setConfig must be implemented')
   }
+
+  /**
+   * Overrides the default settings with the ones passed as a parameter.
+   * @param bidderSettings
+   */
+  setBidderSettings(bidderSettings) {
+    throw new Error('AppNexusConnector#setBidderSettings must be implemented')
+  }
 }

--- a/src/openads-appnexus/PrebidClient.js
+++ b/src/openads-appnexus/PrebidClient.js
@@ -34,15 +34,7 @@ export default class PrebidClient {
    * Defines setConfig.
    * @param config
    */
-  setConfig(config) {
+  setConfig({config}) {
     throw new Error('AppNexusConnector#setConfig must be implemented')
-  }
-
-  /**
-   * Overrides the default settings with the ones passed as a parameter.
-   * @param bidderSettings
-   */
-  setBidderSettings(bidderSettings) {
-    throw new Error('AppNexusConnector#setBidderSettings must be implemented')
   }
 }

--- a/src/openads-appnexus/PrebidClientImpl.js
+++ b/src/openads-appnexus/PrebidClientImpl.js
@@ -37,19 +37,12 @@ export default class PrebidClientImpl {
     return this
   }
 
-  setConfig(config) {
+  setConfig({config = {}} = {}) {
     this._logger.debug(this._logger.name, '| setConfig | config:', config)
-    this._pbjs.que.push(() => this._pbjs.setConfig(config))
-    return this
-  }
-
-  setBidderSettings(bidderSettings) {
-    this._logger.debug(
-      this._logger.name,
-      '| setBidderSettings | bidderSettings:',
-      bidderSettings
-    )
-    this._pbjs.bidderSettings = bidderSettings
+    this._pbjs.que.push(() => {
+      this._pbjs.setConfig(config.core)
+      this._pbjs.bidderSettings = config.bidderSettings
+    })
     return this
   }
 }

--- a/src/openads-appnexus/PrebidClientImpl.js
+++ b/src/openads-appnexus/PrebidClientImpl.js
@@ -42,4 +42,14 @@ export default class PrebidClientImpl {
     this._pbjs.que.push(() => this._pbjs.setConfig(config))
     return this
   }
+
+  setBidderSettings(bidderSettings) {
+    this._logger.debug(
+      this._logger.name,
+      '| setBidderSettings | bidderSettings:',
+      bidderSettings
+    )
+    this._pbjs.bidderSettings = bidderSettings
+    return this
+  }
 }

--- a/src/test/openads-appnexus/AppNexusConnectorTest.js
+++ b/src/test/openads-appnexus/AppNexusConnectorTest.js
@@ -147,9 +147,11 @@ describe('AppNexus Connector', function() {
           member: 1000
         },
         prebidConfig: {
-          bidderTimeout: 1500,
-          priceGranularity: 'dense',
-          enableSendAllBids: false
+          core: {
+            bidderTimeout: 1500,
+            priceGranularity: 'dense',
+            enableSendAllBids: false
+          }
         },
         logger: createLoggerMock(),
         astClient: astClientMock,
@@ -237,9 +239,11 @@ describe('AppNexus Connector', function() {
           member: 1000
         },
         prebidConfig: {
-          bidderTimeout: 1500,
-          priceGranularity: 'dense',
-          enableSendAllBids: false
+          core: {
+            bidderTimeout: 1500,
+            priceGranularity: 'dense',
+            enableSendAllBids: false
+          }
         },
         logger: createLoggerMock(),
         astClient: astClientMock,
@@ -327,9 +331,11 @@ describe('AppNexus Connector', function() {
           member: 1000
         },
         prebidConfig: {
-          bidderTimeout: 1500,
-          priceGranularity: 'dense',
-          enableSendAllBids: false
+          core: {
+            bidderTimeout: 1500,
+            priceGranularity: 'dense',
+            enableSendAllBids: false
+          }
         },
         logger: createLoggerMock(),
         astClient: astClientMock,
@@ -650,7 +656,8 @@ describe('AppNexus Connector', function() {
         addAdUnits: () => {},
         requestBids: requestObj => requestObj.bidsBackHandler(),
         setTargetingForAst: () => null,
-        setConfig: () => null
+        setConfig: () => null,
+        setBidderSettings: () => null
       }
 
       const adRepositoryMock = {
@@ -663,9 +670,65 @@ describe('AppNexus Connector', function() {
           member: 1000
         },
         prebidConfig: {
-          bidderTimeout: 1500,
-          priceGranularity: 'dense',
-          enableSendAllBids: false
+          core: {
+            bidderTimeout: 1500,
+            priceGranularity: 'dense',
+            enableSendAllBids: false
+          },
+          bidderSettings: {
+            standard: {
+              adserverTargeting: [
+                {
+                  key: 'hb_bidder',
+                  val: function(bidResponse) {
+                    return bidResponse.bidderCode
+                  }
+                },
+                {
+                  key: 'hb_adid',
+                  val: function(bidResponse) {
+                    return bidResponse.adId
+                  }
+                },
+                {
+                  key: 'hb_pb',
+                  val: function(bidResponse) {
+                    return bidResponse.pbMg
+                  }
+                },
+                {
+                  key: 'hb_size',
+                  val: function(bidResponse) {
+                    return bidResponse.size
+                  }
+                },
+                {
+                  key: 'hb_source',
+                  val: function(bidResponse) {
+                    return bidResponse.source
+                  }
+                },
+                {
+                  key: 'hb_format',
+                  val: function(bidResponse) {
+                    return bidResponse.mediaType
+                  }
+                },
+                {
+                  key: 'hb_cache_id',
+                  val: function(bidResponse) {
+                    return bidResponse.videoCacheKey
+                  }
+                },
+                {
+                  key: 'hb_uuid',
+                  val: function(bidResponse) {
+                    return bidResponse.videoCacheKey
+                  }
+                }
+              ]
+            }
+          }
         },
         logger: createLoggerMock(),
         astClient: astClientMock,
@@ -678,6 +741,10 @@ describe('AppNexus Connector', function() {
       const setConfigSpy = sinon.spy(prebidClientMock, 'setConfig')
       const requestBidsSpy = sinon.spy(prebidClientMock, 'requestBids')
       const loadTagsSpy = sinon.spy(astClientMock, 'loadTags')
+      const setBidderSettingsSpy = sinon.spy(
+        prebidClientMock,
+        'setBidderSettings'
+      )
 
       const expectedprebidUnitsArray = [
         {
@@ -697,6 +764,7 @@ describe('AppNexus Connector', function() {
             expect(addAdUnitsSpy.calledOnce).to.be.true
             expect(setConfigSpy.called).to.be.true
             expect(requestBidsSpy.calledOnce).to.be.true
+            expect(setBidderSettingsSpy.called).to.be.true
 
             expect(addAdUnitsSpy.args[0][0].adUnits).to.deep.equal(
               expectedprebidUnitsArray
@@ -750,7 +818,8 @@ describe('AppNexus Connector', function() {
         addAdUnits: () => {},
         requestBids: requestObj => requestObj.bidsBackHandler(),
         setTargetingForAst: () => null,
-        setConfig: () => null
+        setConfig: () => null,
+        setBidderSettings: () => null
       }
 
       const adRepositoryMock = {
@@ -763,9 +832,11 @@ describe('AppNexus Connector', function() {
           member: 1000
         },
         prebidConfig: {
-          bidderTimeout: 1500,
-          priceGranularity: 'dense',
-          enableSendAllBids: false
+          core: {
+            bidderTimeout: 1500,
+            priceGranularity: 'dense',
+            enableSendAllBids: false
+          }
         },
         logger: createLoggerMock(),
         astClient: astClientMock,
@@ -778,6 +849,10 @@ describe('AppNexus Connector', function() {
       const setConfigSpy = sinon.spy(prebidClientMock, 'setConfig')
       const requestBidsSpy = sinon.spy(prebidClientMock, 'requestBids')
       const loadTagsSpy = sinon.spy(astClientMock, 'loadTags')
+      const setBidderSettingsSpy = sinon.spy(
+        prebidClientMock,
+        'setBidderSettings'
+      )
 
       const expectedprebidUnitsArray = [
         {
@@ -806,6 +881,7 @@ describe('AppNexus Connector', function() {
             expect(addAdUnitsSpy.calledOnce).to.be.true
             expect(setConfigSpy.called).to.be.true
             expect(requestBidsSpy.calledOnce).to.be.true
+            expect(setBidderSettingsSpy.called).to.be.false
 
             expect(addAdUnitsSpy.args[0][0].adUnits).to.deep.equal(
               expectedprebidUnitsArray

--- a/src/test/openads-appnexus/AppNexusConnectorTest.js
+++ b/src/test/openads-appnexus/AppNexusConnectorTest.js
@@ -78,6 +78,41 @@ describe('AppNexus Connector', function() {
     debugMode: () => null
   })
 
+  const getValidPrebidConfig = () => {
+    return {
+      core: {
+        bidderTimeout: 1500,
+        priceGranularity: 'dense',
+        enableSendAllBids: false
+      },
+      bidderSettings: {
+        standard: {
+          adserverTargeting: [
+            {
+              key: 'hb_bidder',
+              val: function(bidResponse) {
+                return bidResponse.bidderCode
+              }
+            },
+            {
+              key: 'pt0',
+              val: function(bidResponse) {
+                return bidResponse.adId
+              }
+            },
+            {
+              key: 'hb_pb',
+              val: function(bidResponse) {
+                var bucket = (parseFloat(bidResponse.pbCg) * 100).toFixed()
+                return isNaN(bucket) ? '0' : bucket
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+
   describe('constructor', () => {
     it('should call the setPageOpts if options are given', done => {
       const givenPageOpts = {
@@ -85,12 +120,16 @@ describe('AppNexus Connector', function() {
       }
       const astClientMock = createAstClientMock()
       const setPageOptsSpy = sinon.spy(astClientMock, 'setPageOpts')
+      const prebidClientMock = createPrebidClientMock()
+      const setConfigSpy = sinon.spy(prebidClientMock, 'setConfig')
+
       Promise.resolve()
         .then(
           () =>
             new AppNexusConnector({
               pageOpts: givenPageOpts,
-              astClient: astClientMock
+              astClient: astClientMock,
+              prebidClient: prebidClientMock
             })
         )
         .then(() => {
@@ -100,6 +139,7 @@ describe('AppNexus Connector', function() {
             setPageOptsSpy.args[0][0],
             'setPageOpts should receive the pageOpts'
           ).to.deep.equal(givenPageOpts)
+          expect(setConfigSpy.calledOnce).to.be.true
           done()
         })
         .catch(e => done(e))
@@ -146,13 +186,7 @@ describe('AppNexus Connector', function() {
         pageOpts: {
           member: 1000
         },
-        prebidConfig: {
-          core: {
-            bidderTimeout: 1500,
-            priceGranularity: 'dense',
-            enableSendAllBids: false
-          }
-        },
+        prebidConfig: getValidPrebidConfig(),
         logger: createLoggerMock(),
         astClient: astClientMock,
         prebidClient: prebidClientMock,
@@ -238,13 +272,7 @@ describe('AppNexus Connector', function() {
         pageOpts: {
           member: 1000
         },
-        prebidConfig: {
-          core: {
-            bidderTimeout: 1500,
-            priceGranularity: 'dense',
-            enableSendAllBids: false
-          }
-        },
+        prebidConfig: getValidPrebidConfig(),
         logger: createLoggerMock(),
         astClient: astClientMock,
         prebidClient: prebidClientMock,
@@ -330,13 +358,7 @@ describe('AppNexus Connector', function() {
         pageOpts: {
           member: 1000
         },
-        prebidConfig: {
-          core: {
-            bidderTimeout: 1500,
-            priceGranularity: 'dense',
-            enableSendAllBids: false
-          }
-        },
+        prebidConfig: getValidPrebidConfig(),
         logger: createLoggerMock(),
         astClient: astClientMock,
         prebidClient: prebidClientMock,
@@ -382,7 +404,8 @@ describe('AppNexus Connector', function() {
         logger: createLoggerMock(),
         astClient: createAstClientMock(),
         adRepository: createAdRepositoryMock(),
-        loggerProvider: loggerProviderMock
+        loggerProvider: loggerProviderMock,
+        prebidClient: createPrebidClientMock()
       })
 
       appNexusConnector.enableDebug({debug: true})
@@ -403,7 +426,8 @@ describe('AppNexus Connector', function() {
         logger: createLoggerMock(),
         astClient: createAstClientMock(),
         adRepository: createAdRepositoryMock(),
-        loggerProvider: createloggerProviderMock()
+        loggerProvider: createloggerProviderMock(),
+        prebidClient: createPrebidClientMock()
       })
       expect(appNexusConnector.display({})).to.be.a('promise')
     })
@@ -416,7 +440,8 @@ describe('AppNexus Connector', function() {
         logger: createLoggerMock(),
         astClient: astClientMock,
         adRepository: createAdRepositoryMock(),
-        loggerProvider: createloggerProviderMock()
+        loggerProvider: createloggerProviderMock(),
+        prebidClient: createPrebidClientMock()
       })
       const givenId = 1
 
@@ -669,67 +694,7 @@ describe('AppNexus Connector', function() {
         pageOpts: {
           member: 1000
         },
-        prebidConfig: {
-          core: {
-            bidderTimeout: 1500,
-            priceGranularity: 'dense',
-            enableSendAllBids: false
-          },
-          bidderSettings: {
-            standard: {
-              adserverTargeting: [
-                {
-                  key: 'hb_bidder',
-                  val: function(bidResponse) {
-                    return bidResponse.bidderCode
-                  }
-                },
-                {
-                  key: 'hb_adid',
-                  val: function(bidResponse) {
-                    return bidResponse.adId
-                  }
-                },
-                {
-                  key: 'hb_pb',
-                  val: function(bidResponse) {
-                    return bidResponse.pbMg
-                  }
-                },
-                {
-                  key: 'hb_size',
-                  val: function(bidResponse) {
-                    return bidResponse.size
-                  }
-                },
-                {
-                  key: 'hb_source',
-                  val: function(bidResponse) {
-                    return bidResponse.source
-                  }
-                },
-                {
-                  key: 'hb_format',
-                  val: function(bidResponse) {
-                    return bidResponse.mediaType
-                  }
-                },
-                {
-                  key: 'hb_cache_id',
-                  val: function(bidResponse) {
-                    return bidResponse.videoCacheKey
-                  }
-                },
-                {
-                  key: 'hb_uuid',
-                  val: function(bidResponse) {
-                    return bidResponse.videoCacheKey
-                  }
-                }
-              ]
-            }
-          }
-        },
+        prebidConfig: getValidPrebidConfig(),
         logger: createLoggerMock(),
         astClient: astClientMock,
         prebidClient: prebidClientMock,
@@ -738,14 +703,8 @@ describe('AppNexus Connector', function() {
       })
 
       const addAdUnitsSpy = sinon.spy(prebidClientMock, 'addAdUnits')
-      const setConfigSpy = sinon.spy(prebidClientMock, 'setConfig')
       const requestBidsSpy = sinon.spy(prebidClientMock, 'requestBids')
       const loadTagsSpy = sinon.spy(astClientMock, 'loadTags')
-      const setBidderSettingsSpy = sinon.spy(
-        prebidClientMock,
-        'setBidderSettings'
-      )
-
       const expectedprebidUnitsArray = [
         {
           code: 1,
@@ -762,14 +721,10 @@ describe('AppNexus Connector', function() {
         .then(() => {
           setTimeout(() => {
             expect(addAdUnitsSpy.calledOnce).to.be.true
-            expect(setConfigSpy.called).to.be.true
             expect(requestBidsSpy.calledOnce).to.be.true
-            expect(setBidderSettingsSpy.called).to.be.true
-
             expect(addAdUnitsSpy.args[0][0].adUnits).to.deep.equal(
               expectedprebidUnitsArray
             )
-
             expect(loadTagsSpy.calledOnce, 'should have loaded the tag').to.be
               .true
             done()
@@ -831,13 +786,7 @@ describe('AppNexus Connector', function() {
         pageOpts: {
           member: 1000
         },
-        prebidConfig: {
-          core: {
-            bidderTimeout: 1500,
-            priceGranularity: 'dense',
-            enableSendAllBids: false
-          }
-        },
+        prebidConfig: getValidPrebidConfig(),
         logger: createLoggerMock(),
         astClient: astClientMock,
         prebidClient: prebidClientMock,
@@ -846,14 +795,8 @@ describe('AppNexus Connector', function() {
       })
 
       const addAdUnitsSpy = sinon.spy(prebidClientMock, 'addAdUnits')
-      const setConfigSpy = sinon.spy(prebidClientMock, 'setConfig')
       const requestBidsSpy = sinon.spy(prebidClientMock, 'requestBids')
       const loadTagsSpy = sinon.spy(astClientMock, 'loadTags')
-      const setBidderSettingsSpy = sinon.spy(
-        prebidClientMock,
-        'setBidderSettings'
-      )
-
       const expectedprebidUnitsArray = [
         {
           code: 1,
@@ -879,14 +822,10 @@ describe('AppNexus Connector', function() {
         .then(() => {
           setTimeout(() => {
             expect(addAdUnitsSpy.calledOnce).to.be.true
-            expect(setConfigSpy.called).to.be.true
             expect(requestBidsSpy.calledOnce).to.be.true
-            expect(setBidderSettingsSpy.called).to.be.false
-
             expect(addAdUnitsSpy.args[0][0].adUnits).to.deep.equal(
               expectedprebidUnitsArray
             )
-
             expect(loadTagsSpy.calledOnce, 'should have loaded the tag').to.be
               .true
             done()
@@ -904,7 +843,8 @@ describe('AppNexus Connector', function() {
         logger: createLoggerMock(),
         astClient: createAstClientMock(),
         adRepository: adRepositoryMock,
-        loggerProvider: createloggerProviderMock()
+        loggerProvider: createloggerProviderMock(),
+        prebidClient: createPrebidClientMock()
       })
       const givenId = 1
 
@@ -916,11 +856,7 @@ describe('AppNexus Connector', function() {
           segmentation: {a: 5},
           native: {b: 6}
         },
-        prebid: {
-          code: 1,
-          mediaTypes: [[3, 4]],
-          bids: [100, 101]
-        }
+        prebidConfig: getValidPrebidConfig()
       }
       appNexusConnector
         .loadAd({

--- a/src/test/openads-appnexus/PrebidClientImplTest.js
+++ b/src/test/openads-appnexus/PrebidClientImplTest.js
@@ -144,7 +144,7 @@ describe('PrebidClientImpl Test', () => {
   })
 
   describe('setConfig method', () => {
-    it('should call the prebid setConfig method via que', () => {
+    it('should call the prebid setConfig method and set bidderSettings via que', () => {
       const prebidMock = createPrebidMock()
       const loggerMock = createLoggerMock()
       const windowMock = {
@@ -154,17 +154,24 @@ describe('PrebidClientImpl Test', () => {
         logger: loggerMock,
         window: windowMock
       })
+      const givenBidderSettings = {
+        test: 'test'
+      }
       const givenPrebidConfig = {
-        bidderTimeout: 1500,
-        priceGranularity: 'dense',
-        enableSendAllBids: false
+        core: {
+          bidderTimeout: 1500,
+          priceGranularity: 'dense',
+          enableSendAllBids: false
+        },
+        bidderSettings: givenBidderSettings
       }
       const queSpy = sinon.spy(prebidMock.que, 'push')
       const setConfigSpy = sinon.spy(prebidMock, 'setConfig')
 
-      prebidClient.setConfig(givenPrebidConfig)
+      prebidClient.setConfig({config: givenPrebidConfig})
       expect(queSpy.calledOnce).to.be.true
       expect(setConfigSpy.calledOnce).to.be.true
+      expect(windowMock.pbjs.bidderSettings).to.be.equal(givenBidderSettings)
     })
   })
 })


### PR DESCRIPTION
# Background

Library users can not specify custom settings for bidders.

More info can be found [here](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.bidderSettings)

# Goal

Offer a new way to set bidder settings.

# Implementation

- Add a new **setBidderSettings** method to set Bidder Settings. This method will receive an object that will override the default pbjs.bidderSettings.

# Further considerations

bidder settings object must be compliant with prebid specification. More info can be found [here](http://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.bidderSettings)

# Checklist

- [x] The PR relates to *only* one subject with a clear title.
- [x] I have performed a self-review of my own code
- [x] Wrote [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My code is readable by someone else, and I commented the hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# Visual description

![](https://media.giphy.com/media/xUPOqCaonkxSi0Z7Bm/giphy.gif)